### PR TITLE
Add minimum search time and search time variance

### DIFF
--- a/Implementation.cs
+++ b/Implementation.cs
@@ -1366,7 +1366,18 @@ namespace QoL
 			if (__instance.IsInspected())
 				interaction.HoldTime *= Settings.options.containterOpenTimeScale;
 			else
-				interaction.HoldTime = Mathf.Clamp(defaultTime * (Settings.options.containterSearchTimeScalePerItem * __instance.m_GearToInstantiate.Count), defaultTime *0.1f, defaultTime * Settings.options.containterSearchTimeScaleMax);
-		}
+			{
+				interaction.HoldTime = Mathf.Clamp(
+					defaultTime * Settings.options.containterSearchTimeScalePerItem * __instance.m_GearToInstantiate.Count,
+					defaultTime * Settings.options.containterSearchTimeScaleMin,
+					defaultTime * Settings.options.containterSearchTimeScaleMax
+				);
+
+				// Use a user-defined amount of variance to decrease or increase hold time by a random amount
+				// This is done after the fact so that containers with 0 items (common) won't constantly use TimeScaleMin
+				var rand = new System.Random();
+				interaction.HoldTime *= 1.0f + (rand.Next(-100, 100) * Settings.options.containterSearchTimeScaleVar / 100f);
+			}
+        }
 	}
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -56,10 +56,20 @@ namespace QoL
 		[Description("Shortening the time to search containers. For example, by default a container with 3 items will cost 60% of the default time to search.")]
 		public float containterSearchTimeScalePerItem = 0.2f;
 
+		[Name("Container Search Time Min")]
+		[Description("The minimum search time scale.")]
+		[Slider(0.1f, 1f)]
+		public float containterSearchTimeScaleMin = 0.1f;
+
 		[Name("Container Search Time Max")]
 		[Description("The maximum search time scale.")]
 		[Slider(0.4f, 3f)]
 		public float containterSearchTimeScaleMax = 1f;
+
+		[Name("Container Search Time Variance")]
+		[Description("Random variance in search time scale.")]
+		[Slider(0.0f, 1f)]
+		public float containterSearchTimeScaleVar = 0.2f;
 
 		[Name("Crafting Hot Key")]
 		public KeyCode craftingHotkey = KeyCode.X;


### PR DESCRIPTION
* Add SearchTimeScaleMin so that a minimum search time can be set
  rather than falling back to defaultTime * 0.1. The rationale behind
  this is that searching containers should take _some_ amount of time
  and on Interloper it's very common to encounter empty containers. In a
  container heavy place like the dam it may take a couple of hours of
  real game time to search everything and as such impacts player choice.
  Making it so that empty containers are searched almost instantly takes
  away from this consideration. The default value has been left as 0.1
  to preserve existing behavior of the mod.

* Add SearchtimeScaleVar to add a small amount of +/- variance to
  searching containers so that it's not always predictable when
  searching. This was done after the Clamp function as otherwise
  every empty container would just end up using the minimum due to
  the calculated time being 0. A default value of 0.2 was chosen which
  is basically +/-20%. e.g.:

  1 + -100 * .2 / 100 == .8
  1 +  100 * .2 / 100 == 1.2
  1 +   37 * .2 / 100 == 1.074